### PR TITLE
Replace pyfit-sne with opentsne to support OSX, and clean up tutorial notebook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  // Temporary so that Mike's VSCode settings don't reformat all files on save
+  "editor.formatOnSave": false
+}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 Module for analysis of 3D animal pose sequences. Based on work by [Berman et al. (2014)](https://royalsocietypublishing.org/doi/full/10.1098/rsif.2014.0672) and [Marshall et al. (2020)](https://www.sciencedirect.com/science/article/pii/S0896627320308941).
 
 ## Installation
+
 Install the latest version of [Miniconda](https://docs.conda.io/en/latest/miniconda.html) on your machine.
 
 The following steps will clone this repository, set up your conda environment, and install dappy.
+
+Use `environment.yml` if you're on a Linux machine, and `environment_osx.yml` for Mac.
+
 ```
 git clone https://github.com/joshuahwu/dappy.git
 cd dappy
@@ -13,9 +17,11 @@ conda env create -f environment.yml
 conda activate dappy
 pip install -e .
 ```
+
 Note that `pip` and `setuptools` must be updated to the most recent versions.
 
 To begin gaining familiarity with the functionality of this package, download the [demo dataset](https://duke.box.com/v/demo-mouse-poses) and run through the code in `/tutorials/tutorial.ipynb`.
 
 ## Authors
-* **Joshua Wu** - joshua.wu@duke.edu
+
+- **Joshua Wu** - joshua.wu@duke.edu

--- a/configs/tutorial.yaml
+++ b/configs/tutorial.yaml
@@ -1,27 +1,27 @@
 # Folder path of data location
-data_path: './data/'
+data_path: "./data/"
 
 # Output folder of all plots
-out_path: './results/tutorial/'
+out_path: "./results/tutorial/"
 
 # File path of skeletal specifications
-skeleton_path: '../src/dappy/skeletons.py'
+skeleton_path: "../src/dappy/skeletons.py"
 
 # Key of skeleton in the skeletons file
-skeleton_name: 'mouse20_notail'
+skeleton_name: "mouse20_notail"
 
-label: 'fitsne'
+label: "openTSNE"
 downsample: 10
 
 # Parameters for t-SNE embedding
 single_embed:
-  method: 'fitsne'
+  method: "openTSNE"
   perplexity: 50
-  lr: 'auto'
+  lr: "auto"
   sigma: 15
 
 # Parameters for embedding new data into an existing t-SNE embedding
-transform_embed: 
-  method: 'knn'
+transform_embed:
+  method: "knn"
   k: 5
   sigma: 15

--- a/configs/tutorial.yaml
+++ b/configs/tutorial.yaml
@@ -10,12 +10,12 @@ skeleton_path: "../src/dappy/skeletons.py"
 # Key of skeleton in the skeletons file
 skeleton_name: "mouse20_notail"
 
-label: "openTSNE"
+label: "fitsne"
 downsample: 10
 
 # Parameters for t-SNE embedding
 single_embed:
-  method: "openTSNE"
+  method: "fitsne"
   perplexity: 50
   lr: "auto"
   sigma: 15

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -7,7 +7,8 @@ channels:
 dependencies:
   - python=3.8
   - numpy
-  - faiss-gpu=1.7.1
+  # - faiss-gpu=1.7.1
+  - faiss
   - matplotlib
   - seaborn
   - hdf5storage

--- a/src/dappy/embed.py
+++ b/src/dappy/embed.py
@@ -1,3 +1,4 @@
+import functools
 import numpy as np
 import time
 
@@ -5,7 +6,7 @@ from dappy import DataStruct as ds
 from typing import Optional, Union, List
 import faiss
 # import tsnecuda as tc
-import fitsne
+import openTSNE
 import umap
 import tqdm
 
@@ -20,13 +21,13 @@ class Embed:
     def __init__(
         self,
         n_neighbors: int = 150,
-        embed_method: str = "fitsne",
+        embed_method: str = "openTSNE",
         transform_method: str = "knn",
         min_dist: float = 0.5,
         spread: float = 1.0,
         n_iter: int = 1000,
         perplexity: Union[str, int] = "auto",
-        lr: Union[str, int] = "auto",
+        lr: Union[str, float] = "auto",
         k: int = 5,
         n_trees: int = 100,
         embedder=None,
@@ -58,7 +59,7 @@ class Embed:
         n_iter: Optional[int] = None,
         n_neighbors: Optional[int] = None,
         perplexity: Optional[Union[str, int]] = None,
-        lr: Optional[Union[str, int]] = None,
+        lr: Optional[Union[str, float]] = None,
         min_dist: Optional[float] = None,
         spread: Optional[float] = None,
         method: Optional[str] = None,
@@ -103,12 +104,17 @@ class Embed:
             #     learning_rate=lr,
             # )
             # embed_vals = tsne.fit_transform(features)
-        if method == "fitsne":
-            # https://github.com/KlugerLab/pyFIt-SNE
-            print("Running FLtSNE")
-            embed_vals = fitsne.FItSNE( # requires double
-                features.astype(np.double), perplexity=perplexity, learning_rate=lr
-            ).astype(features.dtype)
+        if method == 'openTSNE':
+            print("Running openTSNE")
+
+            partial_tsne = functools.partial(openTSNE.TSNE, learning_rate=lr)
+            if perplexity == "auto":
+                tsne = partial_tsne()
+            else:
+                assert isinstance(perplexity, int)
+                tsne = partial_tsne(perplexity=perplexity)
+            embed_vals = tsne.fit(features)
+
         elif method == "umap":
             print("Running UMAP")
             embedder = umap.UMAP(
@@ -117,6 +123,8 @@ class Embed:
             embed_vals = embedder.fit_transform(features).astype(features.dtype)
             if save_self:
                 self.embedder = embedder
+        else:
+            raise ValueError(f"Unexpected method {method}")
 
         if save_self:
             self.template = features
@@ -192,8 +200,8 @@ class BatchEmbed(Embed):
         sampling_n: int = 20,
         n_neighbors: int = 150,
         sigma: int = 15,
-        batch_method: str = "fitsne",
-        embed_method: str = "fitsne",
+        batch_method: str = "openTSNE",
+        embed_method: str = "openTSNE",
         transform_method: str = "knn",
         min_dist: float = 0.5,
         spread: float = 1.0,

--- a/src/dappy/embed.py
+++ b/src/dappy/embed.py
@@ -21,7 +21,7 @@ class Embed:
     def __init__(
         self,
         n_neighbors: int = 150,
-        embed_method: str = "openTSNE",
+        embed_method: str = "fitsne",
         transform_method: str = "knn",
         min_dist: float = 0.5,
         spread: float = 1.0,
@@ -104,8 +104,8 @@ class Embed:
             #     learning_rate=lr,
             # )
             # embed_vals = tsne.fit_transform(features)
-        if method == 'openTSNE':
-            print("Running openTSNE")
+        if method == 'fitsne':
+            print("Running fitsne via openTSNE")
 
             partial_tsne = functools.partial(openTSNE.TSNE, learning_rate=lr)
             if perplexity == "auto":
@@ -200,8 +200,8 @@ class BatchEmbed(Embed):
         sampling_n: int = 20,
         n_neighbors: int = 150,
         sigma: int = 15,
-        batch_method: str = "openTSNE",
-        embed_method: str = "openTSNE",
+        batch_method: str = "fitsne",
+        embed_method: str = "fitsne",
         transform_method: str = "knn",
         min_dist: float = 0.5,
         spread: float = 1.0,

--- a/tests/float32.py
+++ b/tests/float32.py
@@ -127,7 +127,7 @@ data_obj = ds.DataStruct(
 data_obj.features = pc_feats
 data_obj = data_obj[:: config["downsample"], :]
 
-# Embedding using fitsne
+# Embedding using t-SNE
 embedder = Embed(
     embed_method=config["single_embed"]["method"],
     perplexity=config["single_embed"]["perplexity"],

--- a/tutorials/automated_pipeline.py
+++ b/tutorials/automated_pipeline.py
@@ -90,7 +90,7 @@ def run(features, labels, pose, id, connectivity, paths, params, meta, meta_by_f
     data_obj.features = pc_feats
     data_obj = data_obj[:: params["downsample"], :]
 
-    # Embedding using fitsne
+    # Embedding using t-SNE
     embedder = Embed(
         embed_method=params["single_embed"]["method"],
         perplexity=params["single_embed"]["perplexity"],

--- a/tutorials/tutorial.ipynb
+++ b/tutorials/tutorial.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +320,7 @@
    "outputs": [],
    "source": [
     "# Reshape pose to get egocentric pose features\n",
-    "features, labels = features.get_ego_pose(pose, connectivity.joint_names)\n",
+    "ego_pose, labels = features.get_ego_pose(pose, connectivity.joint_names)\n",
     "\n",
     "# Clear some memory\n",
     "del angles, rel_vel, angle_labels, rel_vel_labels"
@@ -363,11 +363,11 @@
    "source": [
     "t = time.time()\n",
     "pc_feats, pc_labels = features.pca(\n",
-    "    features, labels, categories=[\"ego_euc\"], n_pcs=5, method=\"fbpca\"\n",
+    "    ego_pose, labels, categories=[\"ego_euc\"], n_pcs=5, method=\"fbpca\"\n",
     ")\n",
     "print(\"PCA time: \" + str(time.time() - t))\n",
     "\n",
-    "del features, labels"
+    "del ego_pose, labels"
    ]
   },
   {
@@ -405,7 +405,7 @@
    "outputs": [],
    "source": [
     "wlet_feats, wlet_labels = features.wavelet(\n",
-    "    pc_feats, pc_labels, ids, sample_freq=90, freq=np.linspace(1, 25, 25), w0=5\n",
+    "    pc_feats, pc_labels, ids, f_s=90, freq=np.linspace(1, 25, 25), w0=5\n",
     ")"
    ]
   },
@@ -492,8 +492,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from dappy import embed\n",
+    "import importlib\n",
+    "importlib.reload(embed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from dappy.embed import Embed\n",
-    "# Embedding using fitsne\n",
+    "\n",
     "embedder = Embed(\n",
     "    embed_method=config[\"single_embed\"][\"method\"],\n",
     "    perplexity=config[\"single_embed\"][\"perplexity\"],\n",
@@ -571,7 +582,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.17"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Main change is the move to `openTSNE`:
- `openTSNE` has comparable performance to `pyfit-sne`, but it's better-maintained and has multiplatform support, whereas `pyfit-sne` only works on Linux.
- I made a separate `environment_osx` file, since `faiss-gpu` also only supports Linux, but we want to keep that one for performance reasons.

Minor changes:
- I fixed up some broken sections of the tutorial notebook as I went through it
- A bunch of formatting changes got applied since I have VSCode set up to autoformat as I save. That's just based on my personal setup, but I can set up project-configs later on